### PR TITLE
Add more exit codes and move error messages to exit code enum

### DIFF
--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/AsyncCommand.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/AsyncCommand.java
@@ -55,40 +55,6 @@ public abstract class AsyncCommand extends Command implements PluginIdentifiable
     }
 
     /**
-     * Show a syntax error message when the user fails to enter thr proper syntax
-     * 
-     * @param sender Who failed the command
-     * @param label  The command itself
-     * @param args   Arguments provided to the command
-     */
-    protected void onSyntaxError(CommandSender sender, String label, String[] args){
-        sender.sendMessage(ChatColor.RED+"The syntax you have provided is invalid, please check the command your entered!");
-    };
-
-    /**
-     * Show a permission denied error when the user does not have permission to
-     * execute the command
-     * 
-     * @param sender Who failed the command
-     * @param label  The command itself
-     * @param args   Arguments provided to the command
-     */
-    protected void onPermissionDenied(CommandSender sender, String label, String[] args){
-        sender.sendMessage(ChatColor.RED+"You do not have permission to perform this command!");
-    };
-
-    /**
-     * Show a error when the command fails to execute
-     * 
-     * @param sender Who failed the command
-     * @param label  The command itself
-     * @param args   Arguments provided to the command
-     */
-    protected void onError(CommandSender sender, String label, String[] args){
-        sender.sendMessage(ChatColor.RED+"There was an internal server error while attempting to perform this command, ask the server administrator to read the console");
-    };
-
-    /**
      * Execute the command itself (part of the derived class)
      * 
      * 
@@ -126,21 +92,14 @@ public abstract class AsyncCommand extends Command implements PluginIdentifiable
             @Override
             public Boolean call() {
                 try {
-                    switch (self.executeCommand(sender, commandLabel, args)) {
-                        case EXIT_SUCCESS:
-                            break;
-                        case EXIT_INVALID_SYNTAX:
-                            self.onSyntaxError(sender, commandLabel, args);
-                            break;
-                        case EXIT_PERMISSION_DENIED:
-                            self.onPermissionDenied(sender, commandLabel, args);
-                            break;
-                        case EXIT_ERROR:
-                            self.onError(sender, commandLabel, args);
-                            break;
-                        default:
-                            throw new IllegalArgumentException("The exit code "
-                                    + self.executeCommand(sender, commandLabel, args) + " is out of range");
+                    ExitCode resultingExitCode = self.executeCommand(sender, commandLabel, args);
+
+                    if (resultingExitCode == null) {
+                        throw new IllegalArgumentException("A null exit code was returned");
+                    }
+
+                    if (resultingExitCode.getMessage() != null) {
+                        sender.sendMessage(ChatColor.RED + resultingExitCode.getMessage());
                     }
                 } catch (Throwable ex) {
                     ex.printStackTrace();

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/Command.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/Command.java
@@ -48,40 +48,6 @@ public abstract class Command extends org.bukkit.command.Command implements Plug
         this.owner = owner;
     }
 
-        /**
-     * Show a syntax error message when the user fails to enter thr proper syntax
-     * 
-     * @param sender Who failed the command
-     * @param label  The command itself
-     * @param args   Arguments provided to the command
-     */
-    protected void onSyntaxError(CommandSender sender, String label, String[] args){
-        sender.sendMessage(ChatColor.RED+"The syntax you have provided is invalid, please check the command your entered!");
-    };
-
-    /**
-     * Show a permission denied error when the user does not have permission to
-     * execute the command
-     * 
-     * @param sender Who failed the command
-     * @param label  The command itself
-     * @param args   Arguments provided to the command
-     */
-    protected void onPermissionDenied(CommandSender sender, String label, String[] args){
-        sender.sendMessage(ChatColor.RED+"You do not have permission to perform this command!");
-    };
-
-    /**
-     * Show a error when the command fails to execute
-     * 
-     * @param sender Who failed the command
-     * @param label  The command itself
-     * @param args   Arguments provided to the command
-     */
-    protected void onError(CommandSender sender, String label, String[] args){
-        sender.sendMessage(ChatColor.RED+"There was an internal server error while attempting to perform this command, ask the server administrator to read the console");
-    };
-
     /**
      * Execute the command itself (part of the derived class)
      * 
@@ -113,21 +79,14 @@ public abstract class Command extends org.bukkit.command.Command implements Plug
                     commandLabel, this.owner.getDescription().getFullName()));
 
         try {
-            switch (executeCommand(sender, commandLabel, args)) {
-                case EXIT_SUCCESS:
-                    break;
-                case EXIT_INVALID_SYNTAX:
-                    onSyntaxError(sender, commandLabel, args);
-                    break;
-                case EXIT_PERMISSION_DENIED:
-                    onPermissionDenied(sender, commandLabel, args);
-                    break;
-                case EXIT_ERROR:
-                    onError(sender, commandLabel, args);
-                    break;
-                default:
-                    throw new IllegalArgumentException("The exit code "
-                            + executeCommand(sender, commandLabel, args) + " is out of range");
+            ExitCode resultingExitCode = executeCommand(sender, commandLabel, args);
+
+            if (resultingExitCode == null) {
+                throw new IllegalArgumentException("A null exit code was returned");
+            }
+
+            if (resultingExitCode.getMessage() != null) {
+                sender.sendMessage(ChatColor.RED + resultingExitCode.getMessage());
             }
         } catch (Exception ex) {
             throw new CommandException("Unhandled exception executing command '" + commandLabel + "' in plugin "

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/ExitCode.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/ExitCode.java
@@ -18,6 +18,8 @@
 
 package com.dumbdogdiner.stickyapi.bukkit.command;
 
+import lombok.Getter;
+
 /**
  * Enum based exit codes for StickyAPI command classes.
  */
@@ -25,17 +27,52 @@ public enum ExitCode {
     /**
      * If the command executed successfully
      */
-    EXIT_SUCCESS,
+    EXIT_SUCCESS(null),
     /**
-     * If the command did not execute successfully due to an error
+     * If the command did not execute successfully due to an unexpected error
      */
-    EXIT_ERROR,
+    EXIT_ERROR("There was an internal server error while attempting to perform this command, ask the server administrator to read the console"),
     /**
      * If the sender provided invalid syntax
      */
-    EXIT_INVALID_SYNTAX,
+    EXIT_INVALID_SYNTAX("The syntax you have provided is invalid, please check the command you entered!"),
     /**
      * If the sender did not have permission to execute the command
      */
-    EXIT_PERMISSION_DENIED;
+    EXIT_PERMISSION_DENIED("You do not have permission to perform this command!"),
+    /**
+     * If the sender is of an invalid type (prefer EXIT_MUST_BE_PLAYER when possible)
+     */
+    EXIT_BAD_SENDER("You cannot perform this command as this console or entity!"),
+    /**
+     * If the sender specifically must be a player
+     */
+    EXIT_MUST_BE_PLAYER("You must perform this command as a player!"),
+    /**
+     * If the sender provided valid syntax but is not in a valid state (e.g. running a sell command while empty-handed)
+     */
+    EXIT_INVALID_STATE("You cannot perform this command in this state!"),
+    /**
+     * If the command has a cooldown period and the sender is performing the command too fast
+     */
+    EXIT_COOLDOWN("Please wait before running this command again."),
+    /**
+     * If the command did not execute successfully, but the error was expected and handled cleanly
+     */
+    EXIT_EXPECTED_ERROR("The command could not be performed."),
+    /**
+     * If the command failed, but the command will handle the error message itself. Although there is no difference
+     * between EXIT_SUCCESS and EXIT_ERROR_SILENT, prefer using this exit code when possible for clearer code
+     */
+    EXIT_ERROR_SILENT(null);
+
+    /**
+     * The message to send to the command sender in case of an error, or null if a message should not be sent
+     */
+    @Getter
+    private final String message;
+
+    ExitCode(String message) {
+        this.message = message;
+    }
 }


### PR DESCRIPTION
- Add more exit codes for common errors, e.g. if a command must be run by a player and not the console
- Move error messages into exit code enum to avoid duplicate strings