### PR TITLE
Add wrapper for md_5's TextComponent API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.dumbdogdiner'
-version = '1.3.0'
+version = '1.4.0'
 
 configurations {
     jaxDoclet

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/translation/ChatMessage.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/translation/ChatMessage.java
@@ -1,0 +1,136 @@
+package com.dumbdogdiner.stickyapi.common.translation;
+
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
+
+/**
+ * A Wrapper Class for md_5's TextComponent API.
+ */
+public class ChatMessage {
+
+    private TextComponent msg;
+    private String raw;
+
+    /**
+     * Create a new ChatMessage object
+     * @param content The preformatted Text, this ChatMessage
+     *                should contain.
+     */
+    public ChatMessage(String content) {
+        this.raw = content;
+        TextComponent tc = new TextComponent(content);
+        this.msg = tc;
+    }
+
+    /**
+     * Set the ChatMessage content (overwrites all
+     * appended ChatComponent objects!)
+     *
+     * @param content The new content this ChatMessage
+     *                object should contain
+     * @return The edited ChatMessage object
+     */
+    public ChatMessage setContent(String content) {
+        this.msg = new TextComponent(content);
+        this.raw = content;
+        return this;
+    }
+
+    /**
+     * Returns a String version of this ChatMessage object
+     * @return The raw, unformatted message content
+     */
+    public String getRawContent() {
+        return this.raw;
+    }
+
+    /**
+     * Returns the final, formatted TextComponent of
+     * this ChatMessage wrapper. TextComponents should
+     * be sent via {@code Player#spigot().sendMessage(Component)}
+     *
+     * @return A Spigot-friendly TextComponent object
+     */
+    public TextComponent getComponent() {
+        return msg;
+    }
+
+    /**
+     * Optional method to format URLs within the message.
+     * Converts all urls to a highlighted JSON clickable component.
+     *
+     * @param apply Whether URLs should be formatted.
+     * @return The edited ChatMessage object
+     */
+    public ChatMessage applyURLs(boolean apply) {
+        if(apply) {
+            String original = this.msg.getText();
+            msg = Translation.convertURLs(original);
+        }
+
+        return this;
+    }
+
+    /**
+     * Append another ChatMessage object to this object.
+     * @param chatMessage The ChatMessage that should be added.
+     * @return The edited ChatMessage object
+     */
+    public ChatMessage appendMessage(ChatMessage chatMessage) {
+        if(chatMessage != null) {
+            this.msg.addExtra(chatMessage.getComponent());
+            this.raw = raw + chatMessage.getRawContent();
+        }
+
+
+        return this;
+    }
+
+    /**
+     * Optional method to add a Tooltip to this ChatMessage object.
+     * @param text The String array that should be used for the tooltip content,
+     *             each String represents a new line.
+     * @return The edited ChatMessage object
+     */
+    public ChatMessage setTooltip(String... text) {
+        StringBuilder tooltip = new StringBuilder();
+        int i = 0;
+        for(String s : text) {
+            tooltip.append(s);
+            if(i < text.length - 1) {
+                tooltip.append(System.lineSeparator());
+                i++;
+            }
+        }
+
+        this.msg.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(Translation.translateColors("&", tooltip.toString()))));
+        return this;
+    }
+
+    /**
+     * Optional method to add a URL to this ChatMessage object.
+     * THIS DOES NOT format any URLs, use {@code ChatMessage#applyURLs(boolean)}
+     * if you wish to format URLs within the message itself.
+     *
+     * @param url The URL this message should suggest when clicked.
+     * @return The edited ChatMessage object
+     */
+    public ChatMessage setLink(String url) {
+        this.msg.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
+        return this;
+    }
+
+    /**
+     * Optional method to add a command to this message when clicked.
+     *
+     * @param command The command that should run when message is clicked.
+     * @return The edited ChatMessage object
+     */
+    public ChatMessage setCommand(String command) {
+        this.msg.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command));
+        return this;
+    }
+
+}

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/translation/ChatMessage.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/translation/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.dumbdogdiner.stickyapi.common.translation;
 
+import lombok.Getter;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -10,8 +11,26 @@ import net.md_5.bungee.api.chat.hover.content.Text;
  */
 public class ChatMessage {
 
-    private TextComponent msg;
-    private String raw;
+    /**
+     * The local TextComponent this ChatMessage instance wraps.
+     * -- GETTER --
+     * Returns the final, formatted TextComponent of
+     * this ChatMessage wrapper. TextComponents should
+     * be sent via {@code Player#spigot().sendMessage(Component)}
+     *
+     * @return {@link net.md_5.bungee.api.chat.TextComponent}
+     */
+    @Getter
+    private TextComponent component;
+
+    /**
+     * The raw content this ChatMessage instance wraps.
+     * -- GETTER --
+     * Returns a String version of this ChatMessage object
+     * @return {@link java.lang.String}
+     */
+    @Getter
+    private String rawContent;
 
     /**
      * Create a new ChatMessage object
@@ -19,82 +38,66 @@ public class ChatMessage {
      *                should contain.
      */
     public ChatMessage(String content) {
-        this.raw = content;
-        TextComponent tc = new TextComponent(content);
-        this.msg = tc;
+        this.rawContent = content;
+        this.component = new TextComponent(content);
     }
 
     /**
-     * Set the ChatMessage content (overwrites all
-     * appended ChatComponent objects!)
+     * Set the ChatMessage content - overwrites all
+     * appended ChatComponent objects! Returns the edited
+     * ChatMessage object.
      *
      * @param content The new content this ChatMessage
      *                object should contain
-     * @return The edited ChatMessage object
+     * @return {@link com.dumbdogdiner.stickyapi.common.translation.ChatMessage}
      */
     public ChatMessage setContent(String content) {
-        this.msg = new TextComponent(content);
-        this.raw = content;
+        this.component = new TextComponent(content);
+        this.rawContent = content;
         return this;
-    }
-
-    /**
-     * Returns a String version of this ChatMessage object
-     * @return The raw, unformatted message content
-     */
-    public String getRawContent() {
-        return this.raw;
-    }
-
-    /**
-     * Returns the final, formatted TextComponent of
-     * this ChatMessage wrapper. TextComponents should
-     * be sent via {@code Player#spigot().sendMessage(Component)}
-     *
-     * @return A Spigot-friendly TextComponent object
-     */
-    public TextComponent getComponent() {
-        return msg;
     }
 
     /**
      * Optional method to format URLs within the message.
      * Converts all urls to a highlighted JSON clickable component.
+     * Returns the edited ChatMessage object.
      *
      * @param apply Whether URLs should be formatted.
-     * @return The edited ChatMessage object
+     * @return {@link com.dumbdogdiner.stickyapi.common.translation.ChatMessage}
      */
     public ChatMessage applyURLs(boolean apply) {
         if(apply) {
-            String original = this.msg.getText();
-            msg = Translation.convertURLs(original);
+            String original = this.component.getText();
+            component = Translation.convertURLs(original);
         }
 
         return this;
     }
 
     /**
-     * Append another ChatMessage object to this object.
+     * Append another ChatMessage object to this object. Returns
+     * the edited ChatMessage object.
+     *
      * @param chatMessage The ChatMessage that should be added.
-     * @return The edited ChatMessage object
+     * @return {@link com.dumbdogdiner.stickyapi.common.translation.ChatMessage}
      */
     public ChatMessage appendMessage(ChatMessage chatMessage) {
         if(chatMessage != null) {
-            this.msg.addExtra(chatMessage.getComponent());
-            this.raw = raw + chatMessage.getRawContent();
+            this.component.addExtra(chatMessage.getComponent());
+            this.rawContent = rawContent + chatMessage.getRawContent();
         }
-
-
         return this;
     }
 
     /**
      * Optional method to add a Tooltip to this ChatMessage object.
+     * Returns the edited ChatMessage object.
      * @param text The String array that should be used for the tooltip content,
      *             each String represents a new line.
-     * @return The edited ChatMessage object
+     *
+     * @return {@link com.dumbdogdiner.stickyapi.common.translation.ChatMessage}
      */
-    public ChatMessage setTooltip(String... text) {
+    public ChatMessage setHoverMessage(String... text) {
         StringBuilder tooltip = new StringBuilder();
         int i = 0;
         for(String s : text) {
@@ -105,31 +108,33 @@ public class ChatMessage {
             }
         }
 
-        this.msg.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(Translation.translateColors("&", tooltip.toString()))));
+        this.component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(Translation.translateColors("&", tooltip.toString()))));
         return this;
     }
 
     /**
      * Optional method to add a URL to this ChatMessage object.
      * THIS DOES NOT format any URLs, use {@code ChatMessage#applyURLs(boolean)}
-     * if you wish to format URLs within the message itself.
+     * if you wish to format URLs within the message itself. Returns
+     * the edited ChatMessage object.
      *
      * @param url The URL this message should suggest when clicked.
-     * @return The edited ChatMessage object
+     * @return {@link com.dumbdogdiner.stickyapi.common.translation.ChatMessage}
      */
     public ChatMessage setLink(String url) {
-        this.msg.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
+        this.component.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
         return this;
     }
 
     /**
      * Optional method to add a command to this message when clicked.
+     * Returns the edited ChatMessage object.
      *
      * @param command The command that should run when message is clicked.
-     * @return The edited ChatMessage object
+     * @return {@link com.dumbdogdiner.stickyapi.common.translation.ChatMessage}
      */
     public ChatMessage setCommand(String command) {
-        this.msg.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command));
+        this.component.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command));
         return this;
     }
 

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/translation/Translation.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/translation/Translation.java
@@ -331,7 +331,7 @@ public class Translation {
      *
      * @param text The text that should be converted into
      *             a TextComponent with formatted URLs.
-     * @return A TextComponent containing formatted &
+     * @return A TextComponent containing formatted and
      *         clickable URLs.
      */
     public static TextComponent convertURLs(String text) {

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/translation/Translation.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/translation/Translation.java
@@ -25,13 +25,45 @@ import java.util.function.BiFunction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.dumbdogdiner.stickyapi.common.util.TimeUtil;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
 
 /**
  * A class for parsing configurations
  */
 public class Translation {
+
+    private static final Pattern urlPattern = Pattern.compile("(https:\\/\\/|http:\\/\\/)((?:[-;:&=\\+\\$,\\w]+@)?[A-Za-z0-9.-]+|(www.|[-;:&=\\+\\$,\\w]+@)[A-Za-z0-9.-]+)((?:\\/[\\+~%\\/.\\w-_]*)?\\??(?:[-\\+=&;%@.\\w_]*)#?(?:[\\w]*))?");
+
+    /**
+     * Sub-class for easier URL formatting
+     * between methods.
+     */
+    public static class URLPair {
+        String fullPath;
+        String shortened;
+
+        public URLPair(String fullUrl, String shortenedUrl) {
+            this.fullPath = fullUrl;
+            this.shortened = shortenedUrl;
+        }
+
+        public String getShortened() {
+            return shortened;
+        }
+
+        public String getFullPath() {
+            return fullPath;
+        }
+
+    }
+
     // {VARIABLE|pluralize:"y,ies"}
     private static String pluralize(String lvalue, String arg) {
         String singlar = "", plural = (arg.isEmpty() ? "s" : arg);
@@ -276,4 +308,48 @@ public class Translation {
         retstr = Translation.translateColors(ColorChars, retstr);
         return retstr;
     }
+
+    /**
+     * Find the first URL in a given Text.
+     *
+     * @param text The text that should be checked for URLs
+     * @return A URLPair object which stores the full URL
+     *         as well as a shortened version (e.g. www.github.com)
+     */
+    public static URLPair findURL(String text) {
+        Matcher matcher = urlPattern.matcher(text);
+
+        if(matcher.find()) {
+            return new URLPair(matcher.group(0), matcher.group(2));
+        }
+        return null;
+    }
+
+    /**
+     * Converts URLs in a preformatted String to clickable
+     * JSON components.
+     *
+     * @param text The text that should be converted into
+     *             a TextComponent with formatted URLs.
+     * @return A TextComponent containing formatted &
+     *         clickable URLs.
+     */
+    public static TextComponent convertURLs(String text) {
+        TextComponent finalComp = new TextComponent();
+        for(String s : text.split(" ")) {
+            URLPair url = findURL(s + " ");
+            if((url) == null) {
+                finalComp.addExtra(s + " ");
+            } else {
+                TextComponent urlComponent = new TextComponent(url.getShortened() + " ");
+                urlComponent.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url.getFullPath()));
+                urlComponent.setBold(true);
+                finalComp.addExtra(urlComponent);
+            }
+        }
+
+        return finalComp;
+    }
+
+
 }


### PR DESCRIPTION
* ChatMessage object to allow easier creation of JSON based messages.

```java
ChatMessage message = new ChatMessage("Hello World!")
                          .setTooltip("I'm an example", "and multi-line tooltip!")
                          .setCommand("/broadcast Someone clicked a ChatMessage!");  
```
* Include API methods to detect URL patterns.
* Bumped version to 1.4.0
