### PR TITLE
GitHub Packages Support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: publish
+
+on:
+  release:
+    # Type 'created' will be triggered when a NON-draft release is created and published.
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    container:
+      image: jcxldn/openjdk-alpine:11-jdk
+    steps:
+    - uses: actions/checkout@v2
+    - name: Echo branch name
+      run: echo ${GITHUB_REF##*/}
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Publish with Gradle
+      run: ./gradlew -Pversion=${GITHUB_REF##*/} publish

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'maven-publish'
 }
 group = 'com.dumbdogdiner'
 version = '1.4.3'
@@ -34,4 +35,22 @@ task docs(type: Javadoc) {
     source = sourceSets.main.allJava
     classpath = project.sourceSets.main.runtimeClasspath
     destinationDir = reporting.file("./docs")
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/DumbDogDiner/StickyAPI")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+    publications {
+        gpr(MavenPublication) {
+            from(components.java)
+        }
+    }
 }


### PR DESCRIPTION
Automated GitHub Packages publishing for releases.

When running, the branch name **should** be equal to the tag name from the release.