### PR TITLE
Create superficial Sound enum test

### DIFF
--- a/src/test/java/com/dumbdogdiner/stickyapi/bungeecord/util/SoundTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/bungeecord/util/SoundTest.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Licensed under the MIT license, see LICENSE for more information...
+ */
+package com.dumbdogdiner.stickyapi.bungeecord.util;
+
+import static com.dumbdogdiner.stickyapi_tests_common.TestsCommon.superficialEnumCodeCoverage;
+
+import org.junit.jupiter.api.Test;
+
+public class SoundTest {
+    @Test
+    public void enumSound() {
+        superficialEnumCodeCoverage(Sound.class);
+    }
+}


### PR DESCRIPTION
JaCoCo // pretty much every other test reporter for Java is annoying and counts enums as code that needs tests... so here we are again.

Ironically this bumps code coverage up by  `+30.26%`