### PR TITLE
[WIP] Argument validator

### DIFF
--- a/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/ArgumentItem.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/ArgumentItem.java
@@ -4,8 +4,6 @@
  */
 package com.dumbdogdiner.stickyapi.common.arguments;
 
-import com.dumbdogdiner.stickyapi.common.util.Debugger;
-
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -14,8 +12,6 @@ import org.jetbrains.annotations.NotNull;
 public class ArgumentItem {
     private Arguments parent;
     private String name;
-
-    private final Debugger debug = new Debugger(getClass());
 
     /**
      * Construct a new argument item for the provided Argument class, with the given argument name.

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/ArgumentItem.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/ArgumentItem.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Licensed under the MIT license, see LICENSE for more information...
+ */
+package com.dumbdogdiner.stickyapi.common.arguments;
+
+import com.dumbdogdiner.stickyapi.common.util.Debugger;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Argument component for handling actions against an individual argument.
+ */
+public class ArgumentItem {
+    private Arguments parent;
+    private String name;
+
+    private final Debugger debug = new Debugger(getClass());
+
+    /**
+     * Construct a new argument item for the provided Argument class, with the given argument name.
+     * 
+     * @param parent Parent Arguments class
+     * @param name Name of the individual argument
+     */
+    public ArgumentItem(@NotNull Arguments parent, @NotNull String name) {
+        this.parent = parent;
+        this.name = name;
+    }
+
+    /**
+     * Set a validation method for the argument.
+     * 
+     * @param func the Validator function to register
+     * @return {@link ArgumentItem}
+     */
+    public ArgumentItem validator(@NotNull Arguments.Validator func) {
+        parent.addValidator(name, func);
+        return this;
+    }
+}


### PR DESCRIPTION
Adds an argument validation component to the Arguments class -- could be used to great benefit for plugins which may have multiple subcommands which need specific validation; ideally could also be used in combination with a pre-built handful of "default"/included validators (e.g. `args.requiredString("player").validator(Validators.isOnlinePlayer)` or something).

Still a bit of a WIP:
- I feel the `Validator` interface could be changed a bit to be more type safe (theorycrafting that I could do something with type checking based on the argument validation is being done on)
- Would like to push with a set of default validators based on common in-command validations
- Possibly would like to add some default return messages/a way to pre-define error responses, but would need to play with how it integrates with the ExitCode system more (currently just causes `Arguments.valid()` to fail and lets the `onError` function handle those bits)
- Probably need to rethink how `addValidator()`'s response codes work. Currently just checks parsed args and returns a bool that is basically ignored but... this could be done better?

That said, the validation system _is_ functional and does what it says on the tin -- just could be cleaned up. Would love to hear any thoughts on what could be more beneficial for this application.