### PR TITLE
Re-add the old command API (as @Deprecated)

### DIFF
--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/AsyncCommand.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/AsyncCommand.java
@@ -1,21 +1,7 @@
-/* 
- *  StickyAPI - Utility methods, classes and potentially code-dupe-annihilating code for DDD plugins
- *  Copyright (C) 2020 DumbDogDiner <dumbdogdiner.com>
- *  
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *  
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/*
+ * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Licensed under the MIT license, see LICENSE for more information...
  */
-
 package com.dumbdogdiner.stickyapi.bukkit.command;
 
 import java.util.List;
@@ -42,6 +28,7 @@ import javax.annotation.Nullable;
  * will not cause tick lag if the command takes too long.
  * Please use the with caution!
  */
+@Deprecated
 public abstract class AsyncCommand extends Command implements PluginIdentifiableCommand {
     private Plugin owner;
     private TabCompleter completer;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/AsyncCommand.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/AsyncCommand.java
@@ -1,0 +1,229 @@
+/* 
+ *  StickyAPI - Utility methods, classes and potentially code-dupe-annihilating code for DDD plugins
+ *  Copyright (C) 2020 DumbDogDiner <dumbdogdiner.com>
+ *  
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.dumbdogdiner.stickyapi.bukkit.command;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandException;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.command.PluginIdentifiableCommand;
+import org.bukkit.command.TabCompleter;
+
+import com.dumbdogdiner.stickyapi.StickyAPI;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class is designed to handle execution of commands given by a user or the
+ * console, it runs the command code asynchronously from the server thread and
+ * will not cause tick lag if the command takes too long.
+ * Please use the with caution!
+ */
+public abstract class AsyncCommand extends Command implements PluginIdentifiableCommand {
+    private Plugin owner;
+    private TabCompleter completer;
+
+    /**
+     * Create a new command for the associated plugin
+     * 
+     * @param commandName The name of the command the user will execute
+     * @param owner       The plugin that owns this command.
+     */
+    public AsyncCommand(String commandName, Plugin owner) {
+        super(commandName);
+        this.owner = owner;
+    }
+
+    /**
+     * Execute the command itself (part of the derived class)
+     * 
+     * 
+     * @param sender       Who is executing the command
+     * @param commandLabel The command string triggering this command
+     * @param args         The arguments provided to this command
+     * @return The exit code for the command
+     */
+    // public abstract int executeCommand(Sender sender, String commandLabel, String[] args);
+
+    public abstract ExitCode executeCommand(CommandSender sender, String commandLabel, String[] args);
+
+    /**
+     * This is a vastly simplified command class. We only check if the plugin is
+     * enabled before we execute whereas spigot's `PluginCommand` will attempt to
+     * check permissions beforehand.
+     * 
+     * <p>
+     * This also allows us to do async commands if we so desire and it nulls the
+     * point of CommandExecutors because they were fucking pointless to begin with.
+     * 
+     * @param sender       The person executing the command
+     * @param commandLabel The command that was executed
+     * @param args         The arguments given to the command.
+     * @return {@link ExitCode}
+     */
+    @Override
+    public final boolean execute(CommandSender sender, String commandLabel, String[] args) {
+        if (!this.owner.isEnabled())
+            throw new CommandException(String.format("Cannot execute command \"%s\" in plugin %s - plugin is disabled.",
+                    commandLabel, this.owner.getDescription().getFullName()));
+
+        AsyncCommand self = this;
+        FutureTask<Boolean> t = new FutureTask<>(new Callable<Boolean>() {
+            @Override
+            public Boolean call() {
+                try {
+                    ExitCode resultingExitCode = self.executeCommand(sender, commandLabel, args);
+
+                    if (resultingExitCode == null) {
+                        throw new IllegalArgumentException("A null exit code was returned");
+                    }
+
+                    if (resultingExitCode.getMessage() != null) {
+                        sender.sendMessage(ChatColor.RED + resultingExitCode.getMessage());
+                    }
+                } catch (Throwable ex) {
+                    ex.printStackTrace();
+                    throw new CommandException("Unhandled exception executing command '" + commandLabel + "' in plugin "
+                    + self.owner.getDescription().getFullName(), ex);
+                }
+                return true;
+            }
+        });
+
+        StickyAPI.getPool().execute(t);
+
+        return true; // we always return true, we don't care what bukkit thinks
+    }
+
+    /**
+     * Gets the owner of this PluginCommand
+     *
+     * @return Plugin that owns this command
+     */
+    @Override
+    public Plugin getPlugin() {
+        return this.owner;
+    }
+
+    /**
+     * Sets the {@link CommandExecutor} to run when parsing this command NOTE: This
+     * function does nothing.
+     * 
+     * @param executor New executor to run
+     */
+    public void setExecutor(CommandExecutor executor) {
+        // no-op
+    }
+
+    /**
+     * Gets the {@link CommandExecutor} associated with this command NOTE: These
+     * commands will never have CommandExecutors and will *ALWAYS* return the plugin
+     * itself.
+     * 
+     * @return Plugin.
+     */
+    public CommandExecutor getExecutor() {
+        return this.owner;
+    }
+
+    /**
+     * Sets the {@link TabCompleter} to run when tab-completing this command.
+     * <p>
+     * If no TabCompleter is specified, and the command's executor implements
+     * TabCompleter, then the executor will be used for tab completion.
+     *
+     * @param completer New tab completer
+     */
+    public void setTabCompleter(TabCompleter completer) {
+        this.completer = completer;
+    }
+
+    /**
+     * Gets the {@link TabCompleter} associated with this command.
+     *
+     * @return TabCompleter object linked to this command
+     */
+    public @Nullable TabCompleter getTabCompleter() {
+        return this.completer;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Delegates to the tab completer if present.
+     * <p>
+     * If it is not present or returns null, will delegate to the current command
+     * executor if it implements {@link TabCompleter}. If a non-null list has not
+     * been found, will default to standard player name completion in
+     * {@link Command#tabComplete(CommandSender, String, String[])}.
+     * <p>
+     * This method does not consider permissions.
+     *
+     * @throws CommandException         if the completer or executor throw an
+     *                                  exception during the process of
+     *                                  tab-completing.
+     * @throws IllegalArgumentException if sender, alias, or args is null
+     */
+    @Override
+    public java.util.@NotNull List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, String[] args)
+            throws CommandException, IllegalArgumentException {
+        if (args == null)
+            throw new NullPointerException("arguments to tabComplete cannot be null");
+
+        List<String> completions = null;
+        try {
+            if (completer != null)
+                completions = completer.onTabComplete(sender, this, alias, args);
+        } catch (Throwable ex) {
+            StringBuilder message = new StringBuilder();
+            message.append("Unhandled exception during tab completion for command '/").append(alias).append(' ');
+            for (String arg : args)
+                message.append(arg).append(' ');
+
+            message.deleteCharAt(message.length() - 1).append("' in plugin ")
+                    .append(owner.getDescription().getFullName());
+            throw new CommandException(message.toString(), ex);
+        }
+
+        if (completions == null)
+            return super.tabComplete(sender, alias, args);
+
+        return completions;
+    }
+
+    /**
+     * Convert this command name to a string
+     * 
+     * @return the human readable name of the class
+     */
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder(super.toString());
+        stringBuilder.deleteCharAt(stringBuilder.length() - 1);
+        stringBuilder.append(", ").append(owner.getDescription().getFullName()).append(')');
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/Command.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/Command.java
@@ -1,0 +1,206 @@
+/* 
+ *  StickyAPI - Utility methods, classes and potentially code-dupe-annihilating code for DDD plugins
+ *  Copyright (C) 2020 DumbDogDiner <dumbdogdiner.com>
+ *  
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.dumbdogdiner.stickyapi.bukkit.command;
+
+import java.util.List;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandException;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.command.PluginIdentifiableCommand;
+import org.bukkit.command.TabCompleter;
+
+/**
+ * This class is designed to handle execution of commands given by a user or the
+ * console, it runs the command code synchronously with the server thread and
+ * can cause tick lag if the command takes too long.
+ */
+public abstract class Command extends org.bukkit.command.Command implements PluginIdentifiableCommand {
+    private Plugin owner;
+    private TabCompleter completer;
+
+    /**
+     * Create a new command for the associated plugin
+     * 
+     * @param commandName The name of the command the user will execute
+     * @param owner       The plugin that owns this command.
+     */
+    public Command(String commandName, Plugin owner) {
+        super(commandName);
+        this.owner = owner;
+    }
+
+    /**
+     * Execute the command itself (part of the derived class)
+     * 
+     * @param sender       Who is executing the command
+     * @param commandLabel The command string triggering this command
+     * @param args         The arguments provided to this command
+     * @return Whether or not the command succeeded, returning false will trigger
+     *         onSyntaxError()
+     */
+    public abstract ExitCode executeCommand(CommandSender sender, String commandLabel, String[] args);
+
+    /**
+     * This is a vastly simplified command class. We only check if the plugin is
+     * enabled before we execute whereas spigot's `PluginCommand` will attempt to
+     * check permissions beforehand.
+     * 
+     * This also allows us to do async commands if we so desire and it nulls the
+     * point of CommandExecutors because they were fucking pointless to begin with.
+     * 
+     * @param sender       The person executing the command
+     * @param commandLabel The command that was executed
+     * @param args         The arguments given to the command.
+     * @return {@link ExitCode}
+     */
+    @Override
+    public final boolean execute(CommandSender sender, String commandLabel, String[] args) {
+        if (!this.owner.isEnabled())
+            throw new CommandException(String.format("Cannot execute command \"%s\" in plugin %s - plugin is disabled.",
+                    commandLabel, this.owner.getDescription().getFullName()));
+
+        try {
+            ExitCode resultingExitCode = executeCommand(sender, commandLabel, args);
+
+            if (resultingExitCode == null) {
+                throw new IllegalArgumentException("A null exit code was returned");
+            }
+
+            if (resultingExitCode.getMessage() != null) {
+                sender.sendMessage(ChatColor.RED + resultingExitCode.getMessage());
+            }
+        } catch (Exception ex) {
+            throw new CommandException("Unhandled exception executing command '" + commandLabel + "' in plugin "
+                    + this.owner.getDescription().getFullName(), ex);
+        }
+        return true;
+    }
+
+    /**
+     * Gets the owner of this PluginCommand
+     *
+     * @return Plugin that owns this command
+     */
+    @Override
+    public Plugin getPlugin() {
+        return this.owner;
+    }
+
+    /**
+     * Sets the {@link CommandExecutor} to run when parsing this command NOTE: This
+     * function does nothing.
+     * 
+     * @param executor New executor to run
+     */
+    public void setExecutor(CommandExecutor executor) {
+        // no-op
+    }
+
+    /**
+     * Gets the {@link CommandExecutor} associated with this command NOTE: These
+     * commands will never have CommandExecutors and will *ALWAYS* return the plugin
+     * itself.
+     * 
+     * @return Plugin.
+     */
+    public CommandExecutor getExecutor() {
+        return this.owner;
+    }
+
+    /**
+     * Sets the {@link TabCompleter} to run when tab-completing this command.
+     * <p>
+     * If no TabCompleter is specified, and the command's executor implements
+     * TabCompleter, then the executor will be used for tab completion.
+     *
+     * @param completer New tab completer
+     */
+    public void setTabCompleter(TabCompleter completer) {
+        this.completer = completer;
+    }
+
+    /**
+     * Gets the {@link TabCompleter} associated with this command.
+     *
+     * @return TabCompleter object linked to this command
+     */
+    public TabCompleter getTabCompleter() {
+        return this.completer;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Delegates to the tab completer if present.
+     * <p>
+     * If it is not present or returns null, will delegate to the current command
+     * executor if it implements {@link TabCompleter}. If a non-null list has not
+     * been found, will default to standard player name completion in
+     * {@link Command#tabComplete(CommandSender, String, String[])}.
+     * <p>
+     * This method does not consider permissions.
+     *
+     * @throws CommandException         if the completer or executor throw an
+     *                                  exception during the process of
+     *                                  tab-completing.
+     * @throws IllegalArgumentException if sender, alias, or args is null
+     */
+    @Override
+    public java.util.List<String> tabComplete(CommandSender sender, String alias, String[] args)
+            throws CommandException, IllegalArgumentException {
+        if (sender == null || alias == null || args == null)
+            throw new NullPointerException("arguments to tabComplete cannot be null");
+
+        List<String> completions = null;
+        try {
+            if (completer != null)
+                completions = completer.onTabComplete(sender, this, alias, args);
+        } catch (Throwable ex) {
+            StringBuilder message = new StringBuilder();
+            message.append("Unhandled exception during tab completion for command '/").append(alias).append(' ');
+            for (String arg : args)
+                message.append(arg).append(' ');
+
+            message.deleteCharAt(message.length() - 1).append("' in plugin ")
+                    .append(owner.getDescription().getFullName());
+            throw new CommandException(message.toString(), ex);
+        }
+
+        if (completions == null)
+            return super.tabComplete(sender, alias, args);
+
+        return completions;
+    }
+
+    /**
+     * Convert this command name to a string
+     * 
+     * @return the human readable name of the class
+     */
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder(super.toString());
+        stringBuilder.deleteCharAt(stringBuilder.length() - 1);
+        stringBuilder.append(", ").append(owner.getDescription().getFullName()).append(')');
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/Command.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/Command.java
@@ -1,21 +1,7 @@
-/* 
- *  StickyAPI - Utility methods, classes and potentially code-dupe-annihilating code for DDD plugins
- *  Copyright (C) 2020 DumbDogDiner <dumbdogdiner.com>
- *  
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *  
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/*
+ * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Licensed under the MIT license, see LICENSE for more information...
  */
-
 package com.dumbdogdiner.stickyapi.bukkit.command;
 
 import java.util.List;
@@ -33,6 +19,7 @@ import org.bukkit.command.TabCompleter;
  * console, it runs the command code synchronously with the server thread and
  * can cause tick lag if the command takes too long.
  */
+@Deprecated
 public abstract class Command extends org.bukkit.command.Command implements PluginIdentifiableCommand {
     private Plugin owner;
     private TabCompleter completer;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/ExitCode.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/ExitCode.java
@@ -1,21 +1,7 @@
-/* 
- *  StickyAPI - Utility methods, classes and potentially code-dupe-annihilating code for DDD plugins
- *  Copyright (C) 2020 DumbDogDiner <dumbdogdiner.com>
- *  
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *  
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/*
+ * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Licensed under the MIT license, see LICENSE for more information...
  */
-
 package com.dumbdogdiner.stickyapi.bukkit.command;
 
 import lombok.Getter;
@@ -23,6 +9,7 @@ import lombok.Getter;
 /**
  * Enum based exit codes for StickyAPI command classes.
  */
+@Deprecated
 public enum ExitCode {
     /**
      * If the command executed successfully

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/ExitCode.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/ExitCode.java
@@ -1,0 +1,93 @@
+/* 
+ *  StickyAPI - Utility methods, classes and potentially code-dupe-annihilating code for DDD plugins
+ *  Copyright (C) 2020 DumbDogDiner <dumbdogdiner.com>
+ *  
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.dumbdogdiner.stickyapi.bukkit.command;
+
+import lombok.Getter;
+
+/**
+ * Enum based exit codes for StickyAPI command classes.
+ */
+public enum ExitCode {
+    /**
+     * If the command executed successfully
+     */
+    EXIT_SUCCESS(null),
+    /**
+     * If the command did not execute successfully due to an unexpected error
+     */
+    EXIT_ERROR("There was an internal server error while attempting to perform this command, ask the server administrator to read the console"),
+    /**
+     * If the sender provided invalid syntax
+     */
+    EXIT_INVALID_SYNTAX("The syntax you have provided is invalid, please check the command you entered!"),
+    /**
+     * If the sender did not have permission to execute the command
+     */
+    EXIT_PERMISSION_DENIED("You do not have permission to perform this command!"),
+    /**
+     * If the sender is of an invalid type (prefer EXIT_MUST_BE_PLAYER when possible)
+     */
+    EXIT_BAD_SENDER("You cannot perform this command as this console or entity!"),
+    /**
+     * If the sender specifically must be a player
+     */
+    EXIT_MUST_BE_PLAYER("You must perform this command as a player!"),
+    /**
+     * If the sender provided valid syntax but is not in a valid state (e.g. running a sell command while empty-handed)
+     */
+    EXIT_INVALID_STATE("You cannot perform this command in this state!"),
+    /**
+     * If the command has a cooldown period and the sender is performing the command too fast
+     */
+    EXIT_COOLDOWN("Please wait before running this command again."),
+    /**
+     * If the command did not execute successfully, but the error was expected and handled cleanly
+     */
+    EXIT_EXPECTED_ERROR("The command could not be performed."),
+    /**
+     * If the command failed, but the command will handle the error message itself. Although there is no difference
+     * between EXIT_SUCCESS and EXIT_ERROR_SILENT, prefer using this exit code when possible for clearer code
+     */
+    EXIT_ERROR_SILENT(null);
+
+    /**
+     * The message to send to the command sender in case of an error, or null if a message should not be sent
+     */
+    @Getter
+    private String message;
+
+    ExitCode(String message) {
+        this.message = message;
+    }
+
+    // Allow this message to be defined by the user!!!
+    // This allows us to not have hard-coded exit messages, for example
+    // if I want to provide an example of the syntax when I return EXIT_INVALID_SYNTAX
+    // Returning the ExitCode allows for something like
+    // return ExitCode.EXIT_SUCCESS.setMessage("yay!");
+    /**
+     * Set the message of an {@link ExitCode}
+     * @param message
+     * @return {@link ExitCode}
+     */
+    public ExitCode setMessage(String message) {
+        this.message = message;
+        return this;
+    }
+}

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/CommandUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/CommandUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Licensed under the MIT license, see LICENSE for more information...
+ */
+package com.dumbdogdiner.stickyapi.bukkit.util;
+
+import java.util.List;
+
+import com.dumbdogdiner.stickyapi.common.util.ReflectionUtil;
+
+import org.bukkit.Server;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandMap;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+
+/**
+ * This class is meant to help with Bukkit and Koffee commands
+ */
+@Deprecated
+public class CommandUtil {
+    /**
+     * Register a command with bukkit
+     * @param server The bukkit server
+     * @param command The command to register
+     * @return False if something went wrong
+     */
+    public static boolean registerCommand(Server server, Command command) {
+        try {
+            CommandMap cmap = ReflectionUtil.getProtectedValue(server, "commandMap");
+            cmap.register(server.getName().toLowerCase(), command);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Register a {@link java.util.List} of commands with bukkit
+     * @param server The bukkit server
+     * @param commands The command to register
+     * @return False if something went wrong
+     */
+    public static boolean registerCommands(Server server, List<Command> commands) {
+        try {
+            CommandMap cmap = ReflectionUtil.getProtectedValue(server, "commandMap");
+            cmap.registerAll(server.getName().toLowerCase(), commands);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * Register all commands in a specific package
+     * 
+     * @param server The bukkit server
+     * @param pkg    The package path (e.g. com.ristexsoftware.knappy.commands)
+     * @return False if something went horribly wrong
+     * @throws ClassNotFoundException If the comamnd class cannot be located
+     * @throws IllegalAccessException if the command class represents an abstract class, an interface, an array class, a primitive type, or void; or if the class has no nullary constructor; or if the instantiation fails for some other reason.
+     * @throws InstantiationException If we are unable to instaniate the command class
+     * @deprecated This method uses reflection and is prone to error in later Java
+     *             versions
+     */
+    @Deprecated
+    public static boolean registerCommandPackage(Server server, String pkg)
+            throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+        List<String> classNames;
+        try (ScanResult scanResult = new ClassGraph().acceptPackages(pkg).enableClassInfo().scan()) {
+            classNames = scanResult.getAllClasses().getNames();
+        }
+        for (String className : classNames) {
+            Class<?> clazz = Class.forName(className);
+            Object command = clazz.newInstance(); //FIXME: java.lang.InstantiationException
+            CommandMap cmap = ReflectionUtil.getProtectedValue(server, "commandMap");
+            cmap.register(server.getName().toLowerCase(), (Command)command);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/Arguments.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/Arguments.java
@@ -55,6 +55,17 @@ public class Arguments {
 
     /**
      * Construct a new argument class with the given input.
+     * This is (presently) deprecated syntax, it may be re-added if decided.
+     * @param args Arguments to parse
+     * @since 1.x
+     */
+    @Deprecated
+    public Arguments(@NotNull String [] args){
+        this(Arrays.asList(args));
+    }
+
+    /**
+     * Construct a new argument class with the given input.
      * 
      * @param args Arguments to parse
      * @since 2.0


### PR DESCRIPTION
To allow building legacy code with the current version of StickyAPI, the legacy way to do commands should be re-added with minimal tweaks so that commands can be recompiled with the latest code. This may be fully removed in 3.0, or left as```@Deprecated```. The code will be marked as ```@Deprecated``` to discourage its use.