### PR TITLE
Update all license references to include current year (2021)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 DumbDogDiner
+Copyright (c) 2020-2021 DumbDogDiner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,2 +1,2 @@
-Copyright (c) ${year} DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+Copyright (c) 2020-${year} DumbDogDiner <dumbdogdiner.com>. All rights reserved.
 Licensed under the MIT license, see LICENSE for more information...

--- a/src/main/java/com/dumbdogdiner/stickyapi/StickyAPI.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/StickyAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi;

--- a/src/main/java/com/dumbdogdiner/stickyapi/annotation/Untested.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/annotation/Untested.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.annotation;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/AsyncCommand.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/AsyncCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.command;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/BukkitCommandBuilder.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/BukkitCommandBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.command;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/ExitCode.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/ExitCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.command;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/PluginCommand.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/PluginCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.command;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/command/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/generator/VoidGenerator.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/generator/VoidGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.generator;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/generator/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/generator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/gui/ClickableSlot.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/gui/ClickableSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.gui;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/gui/GUI.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/gui/GUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.gui;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/gui/GUISlot.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/gui/GUISlot.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+/*
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.gui;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/gui/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/gui/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/Orientation.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/Orientation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.particle;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/Parametric.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/Parametric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.particle;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/ParticleSystem.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/ParticleSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.particle;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/Shape.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/Shape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.particle;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/shapes/Circle.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/particle/shapes/Circle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.particle.shapes;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/player/PlayerSnapshot.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/player/PlayerSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.player;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/player/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/player/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/ServerUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/ServerUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/SoundUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/SoundUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/StartupUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/StartupUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/command/BungeeCommandBuilder.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/command/BungeeCommandBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.command;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/packet/PacketRegistration.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/packet/PacketRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.packet;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/packet/SoundPacket.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/packet/SoundPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.packet;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/protocol/Protocol.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/protocol/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.protocol;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/protocol/ProtocolConstants.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/protocol/ProtocolConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.protocol;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/util/Sound.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/util/Sound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/util/SoundUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/util/SoundUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/util/StartupUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/util/StartupUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/ServerVersion.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/ServerVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/Arguments.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.arguments;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/arguments/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/cache/Cache.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/cache/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.cache;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/cache/Cacheable.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/cache/Cacheable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.cache;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/cache/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/cache/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/chat/ChatMessage.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/chat/ChatMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.chat;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/command/CommandBuilder.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/command/CommandBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.command;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/command/ExitCode.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/command/ExitCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.command;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/Configuration.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/ConfigurationOptions.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/ConfigurationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/ConfigurationSection.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/ConfigurationSection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/InvalidConfigurationException.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/InvalidConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/MemoryConfiguration.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/MemoryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/MemoryConfigurationOptions.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/MemoryConfigurationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/MemorySection.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/MemorySection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/FileConfiguration.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/FileConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.file;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/FileConfigurationOptions.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/FileConfigurationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.file;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/YamlConfiguration.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/YamlConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.file;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/YamlConfigurationOptions.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/YamlConfigurationOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.file;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/YamlConstructor.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/YamlConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.file;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/YamlRepresenter.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/YamlRepresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.file;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/file/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/serialization/ConfigurationSerializable.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/serialization/ConfigurationSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.serialization;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/serialization/DelegateDeserialization.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/serialization/DelegateDeserialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.serialization;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/serialization/SerializableAs.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/serialization/SerializableAs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.configuration.serialization;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/serialization/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/configuration/serialization/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/scheduler/Scheduler.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/scheduler/Scheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.scheduler;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/scheduler/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/scheduler/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/translation/Locale.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/translation/Locale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.translation;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/translation/LocaleProvider.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/translation/LocaleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.translation;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/translation/Translation.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/translation/Translation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.translation;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/translation/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/translation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/Debugger.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/Debugger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/FieldUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/FieldUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/IPUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/IPUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/MemoryUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/MemoryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/NotificationType.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/NotificationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/NumberUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/NumberUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/Paginator.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/Paginator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/ReflectionUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/ReflectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/ShortID.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/ShortID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/StringUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/StringUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/TextUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/TextUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/TimeUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/TimeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/UnsafeUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/UnsafeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/package-info.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 /**

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/url/URLPair.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/url/URLPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util.url;

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/url/URLUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/url/URLUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util.url;

--- a/src/test/java/com/dumbdogdiner/stickyapi/bukkit/particle/OrientationTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/bukkit/particle/OrientationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.particle;

--- a/src/test/java/com/dumbdogdiner/stickyapi/bukkit/util/ServerUtilTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/bukkit/util/ServerUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bukkit.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/bungeecord/util/SoundTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/bungeecord/util/SoundTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.bungeecord.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/ServerVersionTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/ServerVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/command/ExitCodeTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/command/ExitCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.command;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/IPUtilTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/IPUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/LuhnTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/LuhnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/MemoryUtilTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/MemoryUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/NotificationTypeTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/NotificationTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/NumberUtilTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/NumberUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/ReflectionUtilInvokeProtectedMethodClassTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/ReflectionUtilInvokeProtectedMethodClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/ReflectionUtilNoSuchFieldTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/ReflectionUtilNoSuchFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/ReflectionUtilTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/ReflectionUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/StringUtilTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/StringUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/TimeUtilTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/TimeUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi.common.util;

--- a/src/test/java/com/dumbdogdiner/stickyapi_tests_common/TestsCommon.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi_tests_common/TestsCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
  * Licensed under the MIT license, see LICENSE for more information...
  */
 package com.dumbdogdiner.stickyapi_tests_common;


### PR DESCRIPTION
- Updated `LICENSE` to show `2020-2021`
- Updated `LICENCE-HEADER` to show `2020-$X`