### PR TITLE
Implement PacketInjector & BukkitHandler

### DIFF
--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/nms/BukkitHandler.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/nms/BukkitHandler.java
@@ -7,6 +7,7 @@ package com.dumbdogdiner.stickyapi.bukkit.nms;
 import io.netty.channel.Channel;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -53,7 +54,7 @@ public class BukkitHandler {
      * @param player Bukkit player object.
      * @return Object of player connection.
      */
-    public static Object getConnection(Player player) {
+    public static Object getConnection(@NotNull Player player) {
         try {
             Object nmsPlayer = getCraftPlayer(player);
             Field conField = nmsPlayer.getClass().getField("playerConnection");
@@ -92,7 +93,7 @@ public class BukkitHandler {
      * @param player Bukkit player object.
      * @return Object of CraftBukkit player.
      */
-    public static Object getCraftPlayer(Player player) {
+    public static Object getCraftPlayer(@NotNull Player player) {
         try {
             return player.getClass().getMethod("getHandle").invoke(player);
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
@@ -110,8 +111,10 @@ public class BukkitHandler {
      * @param player Bukkit player object
      * @param packet Packet object (Must be of type <code>net.minecraft.server.[VERSION].Packet</code>)
      */
-    public static void sendPacket(Player player, Object packet) {
+    public static void sendPacket(@NotNull Player player, @NotNull Object packet) {
         try {
+            Class<?> packetClass = getNMSClass("Packet");
+
             Class<?> nmsPacket = getNMSClass("Packet");
             Object conn = getConnection(player);
 
@@ -131,7 +134,7 @@ public class BukkitHandler {
      * @param service Code that should be executed
      * @param player Bukkit player object
      */
-    public static void injectPlayer(PacketInjector.InjectionService service, Player player) {
+    public static void injectPlayer(PacketInjector.InjectionService service, @NotNull Player player) {
         PacketInjector packetInjector = new PacketInjector();
         packetInjector.addService(service, player);
     }
@@ -145,7 +148,7 @@ public class BukkitHandler {
      *
      * @param player Bukkit player object
      */
-    public static void removeInjection(Player player) {
+    public static void removeInjection(@NotNull Player player) {
         try {
             PacketInjector packetInjector = new PacketInjector();
             Channel ch = packetInjector.getChannel(packetInjector.getNetworkManager(player));

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/nms/BukkitHandler.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/nms/BukkitHandler.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Licensed under the MIT license, see LICENSE for more information...
+ */
+package com.dumbdogdiner.stickyapi.bukkit.nms;
+
+import io.netty.channel.Channel;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class BukkitHandler {
+
+    /**
+     * <p>
+     * Extracts the NMS version from the Bukkit server package
+     * </p>
+     *
+     * @return the NMS version
+     */
+    public static String getNmsVersion() {
+        return Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+    }
+
+    /**
+     * <p>
+     * Gets a class from the <code>org.bukkit.craftbukkit</code> package
+     * </p>
+     *
+     * @param nmsClass CraftBukkit subclass
+     * @return Class object of the specified CraftBukkit subclass.
+     * @throws ClassNotFoundException if class does not exist
+     */
+    public static Class<?> getCraftClass(String nmsClass) throws ClassNotFoundException {
+        String version = getNmsVersion();
+        if(version == null)
+            throw new ClassNotFoundException("Could not find Class " + nmsClass + ": Version is null.");
+
+        String pkg = "org.bukkit.craftbukkit." + version + "." + nmsClass;
+        Class<?> clazz = Class.forName(pkg);
+
+        return clazz;
+    }
+
+    /**
+     * <p>
+     * Gets the CraftBukkit connection object of a player.
+     * </p>
+     *
+     * @param player Bukkit player object.
+     * @return Object of player connection.
+     */
+    public static Object getConnection(Player player) {
+        try {
+            Object nmsPlayer = getCraftPlayer(player);
+            Field conField = nmsPlayer.getClass().getField("playerConnection");
+            Object con = conField.get(nmsPlayer);
+
+            return con;
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    /**
+     * <p>
+     * Gets a class from the <code>net.minecraft.server</code> package
+     * </p>
+     *
+     * @param nmsClass CraftBukkit subclass
+     * @return Class object of the specified CraftBukkit subclass.
+     * @throws ClassNotFoundException when class does not exist
+     */
+    public static Class<?> getNMSClass(String nmsClass) throws ClassNotFoundException {
+        String version = getNmsVersion();
+        if(version == null)
+            throw new ClassNotFoundException("Could not find Class " + nmsClass + ": Version is null.");
+        String pkg = "net.minecraft.server." + version + "." + nmsClass;
+        return Class.forName(pkg);
+    }
+
+    /**
+     * <p>
+     * Gets the CraftBukkit instance of a player.
+     * </p>
+     *
+     * @param player Bukkit player object.
+     * @return Object of CraftBukkit player.
+     */
+    public static Object getCraftPlayer(Player player) {
+        try {
+            return player.getClass().getMethod("getHandle").invoke(player);
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    /**
+     * <p>
+     * Send a packet to a player
+     * </p>
+     *
+     * @param player Bukkit player object
+     * @param packet Packet object (Must be of type <code>net.minecraft.server.[VERSION].Packet</code>)
+     */
+    public static void sendPacket(Player player, Object packet) {
+        try {
+            Class<?> nmsPacket = getNMSClass("Packet");
+            Object conn = getConnection(player);
+
+            Method sendPacket = conn.getClass().getMethod("sendPacket", nmsPacket);
+            sendPacket.invoke(conn, packet);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * <p>
+     * Injects code into a players incoming packet stream using {@link io.netty.channel.ChannelDuplexHandler}.
+     * It's recommended to run this once inside a {@link org.bukkit.event.player.PlayerJoinEvent} listener.
+     * </p>
+     *
+     * @param service Code that should be executed
+     * @param player Bukkit player object
+     */
+    public static void injectPlayer(PacketInjector.InjectionService service, Player player) {
+        PacketInjector packetInjector = new PacketInjector();
+        packetInjector.addService(service, player);
+    }
+
+    /**
+     * <p>
+     * Remove an active code injector from a players incoming packet stream.
+     * If {@link BukkitHandler#injectPlayer(PacketInjector.InjectionService, Player)} was used, it is recommended
+     * to call this method where needed, to avoid negative side affects.
+     * </p>
+     *
+     * @param player Bukkit player object
+     */
+    public static void removeInjection(Player player) {
+        try {
+            PacketInjector packetInjector = new PacketInjector();
+            Channel ch = packetInjector.getChannel(packetInjector.getNetworkManager(player));
+
+            if(ch.pipeline().get(player.getName()) != null) {
+                ch.pipeline().remove(player.getName());
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+}

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/nms/PacketInjector.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/nms/PacketInjector.java
@@ -6,6 +6,7 @@ package com.dumbdogdiner.stickyapi.bukkit.nms;
 
 import io.netty.channel.*;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 
@@ -42,7 +43,7 @@ public class PacketInjector {
         }
     }
 
-    protected void addService(InjectionService service, Player player) {
+    protected void addService(InjectionService service, @NotNull Player player) {
         ChannelDuplexHandler channelDuplexHandler = new ChannelDuplexHandler() {
             @Override
             public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
@@ -78,7 +79,7 @@ public class PacketInjector {
      * @return the NetworkManager object
      * @throws IllegalAccessException may be thrown if the <code>networkManager</code> field can not be accessed
      */
-    protected Object getNetworkManager(Player player) throws IllegalAccessException {
+    protected Object getNetworkManager(@NotNull Player player) throws IllegalAccessException {
         return networkManagerField.get(BukkitHandler.getConnection(player));
     }
 
@@ -91,9 +92,8 @@ public class PacketInjector {
      * @return The {@link io.netty.channel.Channel} object.
      *         May return <code>null</code> if there is no {@link io.netty.channel.Channel} object
      *         or when NetworkManager is null.
-     * @throws IllegalAccessException
      */
-    protected Channel getChannel(Object networkManager) throws IllegalAccessException {
+    protected Channel getChannel(@NotNull Object networkManager) {
         Channel ch = null;
         try {
             ch = (Channel) channel.get(networkManager);

--- a/src/main/java/com/dumbdogdiner/stickyapi/bukkit/nms/PacketInjector.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bukkit/nms/PacketInjector.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020-2021 DumbDogDiner <dumbdogdiner.com>. All rights reserved.
+ * Licensed under the MIT license, see LICENSE for more information...
+ */
+package com.dumbdogdiner.stickyapi.bukkit.nms;
+
+import io.netty.channel.*;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+
+/**
+ * Handles Packet Injection
+ */
+public class PacketInjector {
+
+    public interface InjectionService {
+        /**
+         * <p>
+         * Allows running code before an incoming packet is processed by the server.
+         * </p>
+         *
+         * @param context {@link ChannelHandlerContext}
+         * @param packet Represents the Packet object
+         */
+        void run(ChannelHandlerContext context, Object packet);
+    }
+
+    private Field networkManagerField;
+    private Field channel;
+
+    protected PacketInjector() {
+        try {
+            Class<?> playerConnection = BukkitHandler.getNMSClass("PlayerConnection");
+            networkManagerField = playerConnection.getField("networkManager");
+
+            Class<?> networkManager = BukkitHandler.getNMSClass("NetworkManager");
+            channel = networkManager.getField("channel");
+
+        } catch (ClassNotFoundException | NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected void addService(InjectionService service, Player player) {
+        ChannelDuplexHandler channelDuplexHandler = new ChannelDuplexHandler() {
+            @Override
+            public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
+                service.run(channelHandlerContext, packet);
+                super.channelRead(channelHandlerContext, packet);
+            }
+
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                super.write(ctx, msg, promise);
+            }
+        };
+
+        try {
+            Channel channel = getChannel(getNetworkManager(player));
+            if(channel.pipeline().get(player.getName()) == null) {
+                channel.pipeline().addBefore("packet_handler", player.getName(), channelDuplexHandler);
+            } else {
+                throw new IllegalStateException("Channel '" + player.getName() + "' already exists.");
+            }
+
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
+
+    /**
+     * <p>
+     * Gets the NetworkManager object of a player connection
+     * </p>
+     *
+     * @param player Bukkit player object
+     * @return the NetworkManager object
+     * @throws IllegalAccessException may be thrown if the <code>networkManager</code> field can not be accessed
+     */
+    protected Object getNetworkManager(Player player) throws IllegalAccessException {
+        return networkManagerField.get(BukkitHandler.getConnection(player));
+    }
+
+    /**
+     * <p>
+     * Gets an active channel from a NetworkManager object
+     * </p>
+     *
+     * @param networkManager the NetworkManager object
+     * @return The {@link io.netty.channel.Channel} object.
+     *         May return <code>null</code> if there is no {@link io.netty.channel.Channel} object
+     *         or when NetworkManager is null.
+     * @throws IllegalAccessException
+     */
+    protected Channel getChannel(Object networkManager) throws IllegalAccessException {
+        Channel ch = null;
+        try {
+            ch = (Channel) channel.get(networkManager);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return ch;
+    }
+
+}


### PR DESCRIPTION
* Implemented a util to read imcoming client packets
* Added Bukkit-only reflection methods to get CraftBukkit (and NMS) objects 

Code Example: 
```java
  @EventHandler
  public void onPlayerJoin(PlayerJoinEvent e) {
      BukkitHandler.injectPlayer((channelHandlerContext, packet) -> {
          try {
              if(packet.getClass().getName().contains("PacketPlayInUseEntity")) {
                  Field entIDField = packet.getClass().getDeclaredField("a");
                  Field actionField = packet.getClass().getDeclaredField("action");
                  Field handField = packet.getClass().getDeclaredField("d");

                  entIDField.setAccessible(true);
                  actionField.setAccessible(true);
                  handField.setAccessible(true);

                  int entID = (int) entIDField.get(packet);
                  String action = actionField.get(packet).toString();
                  String hand = handField.get(packet).toString();

                  if(hand.equals("MAIN_HAND") && action.equals("INTERACT")) {
                      System.out.println("Player clicked entity with ID " + entID);
                  }
              }
          } catch (NoSuchFieldException | IllegalAccessException noSuchFieldException) {
              noSuchFieldException.printStackTrace();
          }

      }, e.getPlayer());
  }

  @EventHandler
  public void onPlayerQuit(PlayerQuitEvent e) {
      BukkitHandler.removeInjection(e.getPlayer());
  }
```
Example Output:
```
Player clicked entity with ID 1
```