### PR TITLE
Suppress warnings (unchecked, deprecation)

### DIFF
--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/command/BungeeCommandBuilder.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/command/BungeeCommandBuilder.java
@@ -30,6 +30,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.Plugin;
 
+@SuppressWarnings("deprecation") // PacketRegistration is deprecated
 public class BungeeCommandBuilder extends CommandBuilder<BungeeCommandBuilder> {
 
     // Hmm...

--- a/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/util/SoundUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/bungeecord/util/SoundUtil.java
@@ -36,6 +36,7 @@ public class SoundUtil {
      * @param pitch  The pitch of the sound
      * @param delay  T
      */
+    @SuppressWarnings("deprecation") // SoundPacket is deprecated
     public static void queueSound(@NotNull ProxiedPlayer player, @NotNull Sound sound, @NotNull float volume,
             @NotNull float pitch, @NotNull Long delay) {
         StickyAPI.getPool().submit(() -> {

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/command/CommandBuilder.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/command/CommandBuilder.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import lombok.Getter;
 
+@SuppressWarnings("unchecked") // Supress unchecked cast warnings.
 public abstract class CommandBuilder<T extends CommandBuilder<T>> {
 
     @Getter

--- a/src/main/java/com/dumbdogdiner/stickyapi/common/util/reflection/ReflectionUtil.java
+++ b/src/main/java/com/dumbdogdiner/stickyapi/common/util/reflection/ReflectionUtil.java
@@ -13,7 +13,7 @@ import java.lang.reflect.Modifier;
  * A class for abusing Java and using reflection to unprotect methods and
  * constructors, use this with a lot of care and try not to break things!
  */
-@SuppressWarnings({ "unchecked", "deprecation" })
+@SuppressWarnings("unchecked")
 public final class ReflectionUtil {
     private ReflectionUtil() {
     }

--- a/src/test/java/com/dumbdogdiner/stickyapi/common/util/NumberUtilTest.java
+++ b/src/test/java/com/dumbdogdiner/stickyapi/common/util/NumberUtilTest.java
@@ -27,6 +27,7 @@ public class NumberUtilTest {
     }
 
     @RepeatedTest(100)
+    @SuppressWarnings("deprecation") // getRandomNumber is deprecated
     public void testGetRandomNumber() {
         int number = NumberUtil.getRandomNumber(0, 100);
         assertTrue(number >= 0); // number is 0 or more
@@ -34,6 +35,7 @@ public class NumberUtilTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation") // getRandomNumber is deprecated
     public void testGetRandomNumberIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> {
             NumberUtil.getRandomNumber(1, 0);


### PR DESCRIPTION
**Deprecation**
- `BungeeCommandBuilder`
- `SoundUtil#queueSound`
- `NumberUtilTest#testGetRandomNumber`
- `NumberUtilTest#testGetRandomNumberIllegalArgumentException`

**Unchecked**
- `CommandBuilder`

***Also removed deprecation suppression  from ReflectionUtil***