### PR TITLE
Gradle 7 / Java 16 build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: 
-        version: ["11", "14", "15"]
+        version: ["11", "14", "15", "16"]
     container:
       image: jcxldn/openjdk-alpine:${{matrix.version}}-jdk
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,8 @@ subprojects {
     apply plugin: "io.freefair.lombok"
     apply plugin: "com.diffplug.spotless"
 
-    // Use the edge version of lombok for java 16 compatibility until a release is made
-    // see: https://github.com/rzwitserloot/lombok/issues/2681
-    lombok { version = "edge-SNAPSHOT" }
+    // Use 1.18.20+ for Java 16 compatability
+    lombok { version = "1.18.20" }
 
     // Spotless Options
     spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -306,8 +306,8 @@ task copySubprojectJars(type: Copy, dependsOn: subprojects.jar) {
 task rootJacocoMergedReport(type: JacocoReport) {
   // Gradle 7 implicit dependency fixes
   // -------------------------
-  dependsOn(allprojects.test)
-  dependsOn(allprojects.javadoc)
+  dependsOn(subprojects.test)
+  dependsOn(subprojects.javadoc)
 
   dependsOn(subprojects.delombok)
   dependsOn(subprojects.jacocoTestReport)

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ subprojects {
     apply plugin: "io.freefair.lombok"
     apply plugin: "com.diffplug.spotless"
 
+    // Use the edge version of lombok for java 16 compatibility until a release is made
+    // see: https://github.com/rzwitserloot/lombok/issues/2681
+    lombok { version = "edge-SNAPSHOT" }
+
     // Spotless Options
     spotless {
         encoding 'UTF-8' // all formats will be interpreted as UTF-8
@@ -113,9 +117,6 @@ subprojects {
     }
 
     dependencies {
-        compileOnly "org.projectlombok:lombok:1.18.18"
-        annotationProcessor "org.projectlombok:lombok:1.18.18"
-
         implementation "org.jetbrains:annotations:20.1.0"
         implementation "io.github.classgraph:classgraph:4.8.104"
         implementation "com.github.seancfoley:ipaddress:5.3.3"

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,6 @@ subprojects {
 
     repositories {
         // Note: Maven Central is defined in allprojects
-        //jcenter()
 
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://papermc.io/repo/repository/maven-public/" }
@@ -221,9 +220,8 @@ task copySubprojectJars(type: Copy, dependsOn: subprojects.jar) {
 // Generate an additional jacoco report project-wide
 // src: https://github.com/gradle/gradle/issues/10708#issuecomment-566279825
 task rootJacocoMergedReport(type: JacocoReport) {
-  //dependsOn = subprojects.test
-
   // Gradle 7 implicit dependency fixes
+  // -------------------------
   dependsOn(allprojects.test)
   dependsOn(allprojects.javadoc)
 
@@ -233,11 +231,7 @@ task rootJacocoMergedReport(type: JacocoReport) {
   dependsOn(aggregateJavadoc)
   dependsOn(copySubprojectJars)
   dependsOn(rootTestReport)
-
-//  dependsOn(subprojects.sources)
-//  dependsOn(rootSources)
-//  dependsOn(subprojects.test)
-//  dependsOn(subprojects.compileTestJava)
+  // -------------------------
 
   additionalSourceDirs.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
   sourceDirectories.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)

--- a/build.gradle
+++ b/build.gradle
@@ -169,8 +169,7 @@ subprojects {
     }
 
     repositories {
-        // Note: Maven Central is defined in allprojects
-
+        // Maven Central is defined in allprojects (for JaCoCo)
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://papermc.io/repo/repository/maven-public/" }
 

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects {
 
     repositories {
         // Note: Maven Central is defined in allprojects
-        jcenter()
+        //jcenter()
 
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://papermc.io/repo/repository/maven-public/" }
@@ -188,6 +188,10 @@ jar { from subprojects.sourceSets.main.output }
 
 // Root build: create uber sources from subproject sources
 task rootSources(type: Jar, dependsOn: classes) {
+    // Gradle 7 implicit dependency fix: depend on special common tasks
+    dependsOn(":common:copyMCFontExtractor")
+    dependsOn(":common:commonSources")
+
     archiveClassifier.set("sources")
     // Use source code from all subprojects for sources.
     // TODO: Use certain subprojects only to allow for multiple jar outputs
@@ -202,10 +206,39 @@ task rootTestReport(type: TestReport) {
     reportOn subprojects*.test
 }
 
+// Create a libs/modules folder with submodule jars
+task copySubprojectJars(type: Copy, dependsOn: subprojects.jar) {
+    // Gradle 7 implicit dependency fix: depend on special common tasks
+    dependsOn(":common:copyMCFontExtractor")
+    dependsOn(":common:commonSources")
+
+    // Copy subproject jar and sources
+    from(subprojects.jar) 
+    from(subprojects.sources)
+    into rootProject.file("build/libs/modules")
+}
+
 // Generate an additional jacoco report project-wide
 // src: https://github.com/gradle/gradle/issues/10708#issuecomment-566279825
 task rootJacocoMergedReport(type: JacocoReport) {
   //dependsOn = subprojects.test
+
+  // Gradle 7 implicit dependency fixes
+  dependsOn(allprojects.test)
+  dependsOn(allprojects.javadoc)
+
+  dependsOn(subprojects.delombok)
+  dependsOn(subprojects.jacocoTestReport)
+
+  dependsOn(aggregateJavadoc)
+  dependsOn(copySubprojectJars)
+  dependsOn(rootTestReport)
+
+//  dependsOn(subprojects.sources)
+//  dependsOn(rootSources)
+//  dependsOn(subprojects.test)
+//  dependsOn(subprojects.compileTestJava)
+
   additionalSourceDirs.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
   sourceDirectories.setFrom files(subprojects.sourceSets.main.allSource.srcDirs)
   classDirectories.setFrom files(subprojects.sourceSets.main.output)
@@ -214,14 +247,6 @@ task rootJacocoMergedReport(type: JacocoReport) {
     xml.enabled true
     html.enabled true
   }
-}
-
-// Create a libs/modules folder with submodule jars
-task copySubprojectJars(type: Copy, dependsOn: subprojects.jar) {
-    // Copy subproject jar and sources
-    from(subprojects.jar) 
-    from(subprojects.sources)
-    into rootProject.file("build/libs/modules")
 }
 
 // Root build: run copySubprojectJars after build

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 
 // Use --add-opens to ensure functionality of FieldUtil [java.lang.reflect.Field] (required in Java 16+)
 // This will export java.lang.reflect to unnamed modules (eg. stickyapi) so that FieldUtil can still function.
-// alternate: ["--illegal-access=warn"] (same functionality as pre Java 16)
-// jep: https://openjdk.java.net/jeps/396
+// Alternative: ["--illegal-access=warn"] (same functionality as pre Java 16)
+// JEP: https://openjdk.java.net/jeps/396
 test.jvmArgs = ["--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"]
 
 /*

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     compileOnly "commons-lang:commons-lang:2.6"
 }
 
+// Use --add-opens to ensure functionality of FieldUtil [java.lang.reflect.Field] (required in Java 16+)
+// This will export java.lang.reflect to unnamed modules (eg. stickyapi) so that FieldUtil can still function.
+// alternate: ["--illegal-access=warn"] (same functionality as pre Java 16)
+// jep: https://openjdk.java.net/jeps/396
+test.jvmArgs = ["--add-opens=java.base/java.lang.reflect=ALL-UNNAMED"]
+
 /*
     Build Info
     ----------

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -105,8 +105,8 @@ task copyMCFontExtractor(type: Copy) {
     rename "mc-font-extractor-main-mojangles_width_data.json", "mojangles_width_data.json"
 }
 
-// Run the font data copier before compiling the source code.
-tasks.compileJava.dependsOn copyMCFontExtractor
+// Run the font data copier
+tasks.processResources.dependsOn copyMCFontExtractor
 
 
 // Common build: create a jar from the :common & :common:serverversion projects

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-compileJava.options.encoding=UTF-8


### PR DESCRIPTION
Most of the groundwork was laid out in #97.

~~Setting as a draft due to the pre-release nature of this PR.~~

## Changes in this PR:

- Switched to gradle wrapper `7.0`
- Added java 16 to CI matrix
- Remove duplicate lombok dependency (already provided by plugin)

### Gradle 7 specific changes
- Remove `jcenter()` repository
- Add `dependsOn` to `rootSources`, `copySubProjectJars` and `rootJacocoMergedReport` to resolve gradle 7 implicit dependency warnings

### Java 16 specific changes
- ~~Switch to lombok `edge-SNAPSHOT` (awaiting formal tagged release, see https://github.com/rzwitserloot/lombok/issues/2681)~~
- Updated lombok for Java 16 compatability
- Add an `--add-opens` for `:common:test` to preserve FieldUtil functionality