### PR TITLE
(3.0.0 hotfix)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,6 +247,9 @@ tasks.build.dependsOn rootSources
 // Root build: generate project wide test, coverage and javadoc results
 tasks.build.finalizedBy rootTestReport, rootJacocoMergedReport, aggregateJavadoc
 
+// Subproject Javadoc: Finalize :javadoc meta-task with :aggregateJavadoc
+task javadoc { finalizedBy aggregateJavadoc }
+
 // Javadoc fixes (pt. 2, see above entries)
 aggregateJavadoc.options.encoding = "UTF-8"
 

--- a/build.gradle
+++ b/build.gradle
@@ -182,17 +182,6 @@ subprojects {
 
                     from(components.java)
                     artifact sources // Publish the output of the sources task
-
-                    // 3.0.1 hotfix: Exclude serverversion from the outputted pom (since it's unresolvable outside of this repo)
-                    pom.withXml {
-                        Node pomNode = asNode()
-                        pomNode.dependencies.'*'.findAll() {
-                            it.groupId.text() == "com.dumbdogdiner"
-                            it.artifactId.text() == "serverversion"
-                        }.each() {
-                            it.parent().remove(it)
-                        }
-                    }
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,7 @@ aggregateJavadoc.options.encoding = "UTF-8"
 
 // Root Javadoc: Set title and output dir
 aggregateJavadoc.title = "StickyAPI $project.version API (Aggregated)"
-aggregateJavadoc.destinationDir = project.file("$buildDir/docs/javadoc")
+aggregateJavadoc.destinationDir = file("$buildDir/docs/javadoc")
 
 task browseJavadoc {
     dependsOn aggregateJavadoc

--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,9 @@ javaPlatform.allowDependencies()
 // Root build: Add api dependency to all projects we wanna include
 dependencies {
     project.subprojects.each {
-        if (it.name != "serverversion") api it
+        if (it.name != "serverversion") api (it) {
+            exclude group: "com.dumbdogdiner", module: "serverversion"
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,17 @@ subprojects {
 
                     from(components.java)
                     artifact sources // Publish the output of the sources task
+
+                    // 3.0.1 hotfix: Exclude serverversion from the outputted pom (since it's unresolvable outside of this repo)
+                    pom.withXml {
+                        Node pomNode = asNode()
+                        pomNode.dependencies.'*'.findAll() {
+                            it.groupId.text() == "com.dumbdogdiner"
+                            it.artifactId.text() == "serverversion"
+                        }.each() {
+                            it.parent().remove(it)
+                        }
+                    }
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,16 @@ plugins {
     id "com.diffplug.spotless" version "5.11.0" apply false
     // generation of project-wide javadocs
     id "io.freefair.aggregate-javadoc" version "5.3.0"
+
+    // pom packaging for root
+    id "java-platform"
 }
 
 allprojects {
     group = "com.dumbdogdiner"
     version = "3.0.0"
 
-    apply plugin: "java"
+    // java plugin is applied in subprojects
     apply plugin: "jacoco"
 
     // Apply here instead of in plugins {} above to solve
@@ -69,6 +72,9 @@ allprojects {
 subprojects {
     apply plugin: "io.freefair.lombok"
     apply plugin: "com.diffplug.spotless"
+    
+    // apply the java plugin here since root uses java-platform
+    apply plugin: "java"
 
     // Spotless Options
     spotless {
@@ -193,11 +199,18 @@ subprojects {
     }
 }
 
-// Root build: create uber jar from subproject outputs
-jar { from subprojects.sourceSets.main.output }
+// Root build: include dependencies (see below)
+javaPlatform.allowDependencies()
+
+// Root build: Add api dependency to all projects we wanna include
+dependencies {
+    project.subprojects.each {
+        if (it.name != "serverversion") api it
+    }
+}
 
 // Root build: create uber sources from subproject sources
-task rootSources(type: Jar, dependsOn: classes) {
+task rootSources(type: Jar, dependsOn: subprojects.classes) {
     archiveClassifier.set("sources")
     // Use source code from all subprojects for sources.
     // TODO: Use certain subprojects only to allow for multiple jar outputs
@@ -241,16 +254,13 @@ tasks.build.finalizedBy copySubprojectJars
 tasks.build.dependsOn rootSources
 
 // Root build: generate project wide test, coverage and javadoc results
-tasks.test.finalizedBy rootTestReport, rootJacocoMergedReport, javadoc
-
-// Root build: also run aggregateJavadoc after javadoc to generate project-wide javadocs
-tasks.javadoc.finalizedBy aggregateJavadoc
+tasks.build.finalizedBy rootTestReport, rootJacocoMergedReport, aggregateJavadoc
 
 // Javadoc fixes (pt. 2, see above entries)
 aggregateJavadoc.options.encoding = "UTF-8"
 
 task browseJavadoc {
-    dependsOn javadoc
+    dependsOn aggregateJavadoc
     description "Browse javadoc"
     group = "documentation"
     doLast {
@@ -264,7 +274,7 @@ publishing {
     // Uber-jar publication
     publications {
         gprRoot(MavenPublication) {
-            from(components.java)
+            from(components.javaPlatform)
             artifact rootSources // Publish the output of the (root) sources task
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -250,6 +250,10 @@ tasks.build.finalizedBy rootTestReport, rootJacocoMergedReport, aggregateJavadoc
 // Javadoc fixes (pt. 2, see above entries)
 aggregateJavadoc.options.encoding = "UTF-8"
 
+// Root Javadoc: Set title and output dir
+aggregateJavadoc.title = "StickyAPI $project.version API (Aggregated)"
+aggregateJavadoc.destinationDir = project.file("$buildDir/docs/javadoc")
+
 task browseJavadoc {
     dependsOn aggregateJavadoc
     description "Browse javadoc"

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.dumbdogdiner"
-    version = "3.0.0"
+    version = "3.0.1"
 
     // java plugin is applied in subprojects
     apply plugin: "jacoco"


### PR DESCRIPTION
Hotfix: replace `java` with `java-platform` with an exclude for `:serverversion`


Issue:
1. `stickyapi-common` depended on `serverversion`, which is not published
2. `stickyapi` had no dependencies

Edit: if the root jar is now effectively a meta package (just a pom pointing to other modules) do we still need rootSources? 🤔 

**Issues**
- [x] `stickyapi X.X.X API` title missing from aggregate javadocs
  - Now shows: `StickyAPI X.X.X API (Aggregated)`