### PR TITLE
(3.0.2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,44 @@ allprojects {
         // Include private and protected in the javadocs
         options.memberLevel = JavadocMemberLevel.PRIVATE
     }
+
+    // -------------------------
+    // Check for unresolvable packages (works on root and subprojects)
+    // -------------------------
+    // Define unresolvable packages here
+    def unresolvablePackages = ["serverversion"]
+    // Define the default configuration to check (in this case the one from the "java" plugin used in our subprojects)
+    def configurationToCheck = "runtimeClasspath"
+    // Define the task itself
+    task checkForUnresolvablePackages {
+        // Set metadata
+        description = "Check that no unresolvable packages are in the given configuration"
+        group = "verification"
+        doLast {
+            println("Checking project '$project.name' for unresolvable packages...")
+            // Root project: "runtimeClasspath" not available, use "classpath" configuration instead
+            if (project.name == rootProject.name) configurationToCheck = "classpath"
+            println("Using configuration '$configurationToCheck'")
+            // Iterate through each dependency in the given configuration
+            configurations[configurationToCheck].allDependencies.each {
+                println("[debug] Checking '$it.group:$it.name:$it.version'")
+                // Check if it's in our list AND has the same group as the root project
+                // (To make sure it's actually from this codebase)
+                if (unresolvablePackages.contains(it.name) && it.group == rootProject.group) {
+                    // Print to console, and also call ant.fail to fail the entire build.
+                    def errMsg = "Found unresolvable dependency '$it.group:$it.name' in project '$project.name'!"
+                    println(errMsg)
+                    ant.fail(errMsg)
+                }
+            }
+            // Otherwise, the check passed!
+            println("Unresolvable packages check for project '$name' completed successfully!")
+        }
+    }
+    
+    // Finalize the build task with this task on every project.
+    build.finalizedBy checkForUnresolvablePackages
+    // -------------------------
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.dumbdogdiner"
-    version = "3.0.1"
+    version = "3.0.2"
 
     // java plugin is applied in subprojects
     apply plugin: "jacoco"

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -1,9 +1,18 @@
+plugins {
+    // for "api" in dependencies { }
+    id "java-library"
+}
+
 dependencies {
         implementation project(":common")
         testImplementation project(":common").sourceSets.test.output
 
-        // 3.0.1: serverversion is not transistive from common
-        implementation project(":common:serverversion")
+        // 3.0.2: serverversion is not transistive from common
+        // Since we depend on common, the class is still available at runtime
+        // -------------------------
+        // Why: "compileOnly" | This typically includes dependencies which are shaded when found at runtime.
+        // Source: https://docs.gradle.org/6.8.3/userguide/java_library_plugin.html
+        compileOnly project(":common:serverversion")
 
         compileOnly "com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT"
 


### PR DESCRIPTION
# Changes

**Enhancements**
* Created a `checkForUnresolvablePackages`
  * Compatible with root + sub projects
  * Checks that (eg. serverversion) is not included in the given configuration (`runtimeClasspath` for subprojects; `classpath` for the root project)
  * Added to allprojects' build.finalizedBy

**Bugfix**
* In `bukkit/build.gradle`, the dependency on `project(":common:serverversion")` has been switched to compileOnly (see in-file comments) 

# Testing
-------------

**Setup command**
`./gradlew clean build publishToMavenLocal`

### Test `build.gradle`:
```groovy
apply plugin: "java"

repositories {
    mavenLocal()
    mavenCentral()
}
dependencies {
    //implementation "com.dumbdogdiner:stickyapi-config:3.0.2"
    //implementation platform("com.dumbdogdiner:stickyapi:3.0.2")
}
```

# All Modules
`implementation platform("com.dumbdogdiner:stickyapi:3.0.2")`
```groovy
> Task :dependencies

------------------------------------------------------------
Root project
------------------------------------------------------------

annotationProcessor - Annotation processors and their dependencies for source set 'main'.
No dependencies

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts. (n)
No dependencies

compileClasspath - Compile classpath for source set 'main'.
\--- com.dumbdogdiner:stickyapi:3.0.2
     +--- com.dumbdogdiner:stickyapi-bukkit:3.0.2
     +--- com.dumbdogdiner:stickyapi-bungee:3.0.2
     +--- com.dumbdogdiner:stickyapi-common:3.0.2
     |    \--- com.dumbdogdiner:stickyapi-config:3.0.2
     \--- com.dumbdogdiner:stickyapi-config:3.0.2

compileOnly - Compile only dependencies for source set 'main'. (n)
No dependencies

default - Configuration for default artifacts. (n)
No dependencies

implementation - Implementation only dependencies for source set 'main'. (n)
\--- com.dumbdogdiner:stickyapi:3.0.2 (n)

runtimeClasspath - Runtime classpath of source set 'main'.
\--- com.dumbdogdiner:stickyapi:3.0.2
     +--- com.dumbdogdiner:stickyapi-bukkit:3.0.2
     |    +--- org.jetbrains:annotations:20.1.0
     |    +--- io.github.classgraph:classgraph:4.8.104
     |    +--- com.github.seancfoley:ipaddress:5.3.3
     |    \--- com.dumbdogdiner:stickyapi-common:3.0.2
     |         +--- org.jetbrains:annotations:20.1.0
     |         +--- io.github.classgraph:classgraph:4.8.104
     |         +--- com.github.seancfoley:ipaddress:5.3.3
     |         +--- com.google.code.gson:gson:2.8.6
     |         \--- com.dumbdogdiner:stickyapi-config:3.0.2
     |              +--- org.jetbrains:annotations:20.1.0
     |              +--- io.github.classgraph:classgraph:4.8.104
     |              \--- com.github.seancfoley:ipaddress:5.3.3
     +--- com.dumbdogdiner:stickyapi-bungee:3.0.2
     |    +--- org.jetbrains:annotations:20.1.0
     |    +--- io.github.classgraph:classgraph:4.8.104
     |    +--- com.github.seancfoley:ipaddress:5.3.3
     |    \--- com.dumbdogdiner:stickyapi-common:3.0.2 (*)
     +--- com.dumbdogdiner:stickyapi-common:3.0.2 (*)
     \--- com.dumbdogdiner:stickyapi-config:3.0.2 (*)

runtimeElements - Elements of runtime for main. (n)
No dependencies

runtimeOnly - Runtime only dependencies for source set 'main'. (n)
No dependencies

testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
No dependencies

testCompileClasspath - Compile classpath for source set 'test'.
\--- com.dumbdogdiner:stickyapi:3.0.2
     +--- com.dumbdogdiner:stickyapi-bukkit:3.0.2
     +--- com.dumbdogdiner:stickyapi-bungee:3.0.2
     +--- com.dumbdogdiner:stickyapi-common:3.0.2
     |    \--- com.dumbdogdiner:stickyapi-config:3.0.2
     \--- com.dumbdogdiner:stickyapi-config:3.0.2

testCompileOnly - Compile only dependencies for source set 'test'. (n)
No dependencies

testImplementation - Implementation only dependencies for source set 'test'. (n)
No dependencies

testRuntimeClasspath - Runtime classpath of source set 'test'.
\--- com.dumbdogdiner:stickyapi:3.0.2
     +--- com.dumbdogdiner:stickyapi-bukkit:3.0.2
     |    +--- org.jetbrains:annotations:20.1.0
     |    +--- io.github.classgraph:classgraph:4.8.104
     |    +--- com.github.seancfoley:ipaddress:5.3.3
     |    \--- com.dumbdogdiner:stickyapi-common:3.0.2
     |         +--- org.jetbrains:annotations:20.1.0
     |         +--- io.github.classgraph:classgraph:4.8.104
     |         +--- com.github.seancfoley:ipaddress:5.3.3
     |         +--- com.google.code.gson:gson:2.8.6
     |         \--- com.dumbdogdiner:stickyapi-config:3.0.2
     |              +--- org.jetbrains:annotations:20.1.0
     |              +--- io.github.classgraph:classgraph:4.8.104
     |              \--- com.github.seancfoley:ipaddress:5.3.3
     +--- com.dumbdogdiner:stickyapi-bungee:3.0.2
     |    +--- org.jetbrains:annotations:20.1.0
     |    +--- io.github.classgraph:classgraph:4.8.104
     |    +--- com.github.seancfoley:ipaddress:5.3.3
     |    \--- com.dumbdogdiner:stickyapi-common:3.0.2 (*)
     +--- com.dumbdogdiner:stickyapi-common:3.0.2 (*)
     \--- com.dumbdogdiner:stickyapi-config:3.0.2 (*)

testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
No dependencies

(*) - dependencies omitted (listed previously)

(n) - Not resolved (configuration is not meant to be resolved)

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```

# Common
`implementation "com.dumbdogdiner:stickyapi-common:3.0.2"`
```groovy
> Task :dependencies

------------------------------------------------------------
Root project
------------------------------------------------------------

annotationProcessor - Annotation processors and their dependencies for source set 'main'.
No dependencies

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts. (n)
No dependencies

compileClasspath - Compile classpath for source set 'main'.
\--- com.dumbdogdiner:stickyapi-common:3.0.2
     \--- com.dumbdogdiner:stickyapi-config:3.0.2

compileOnly - Compile only dependencies for source set 'main'. (n)
No dependencies

default - Configuration for default artifacts. (n)
No dependencies

implementation - Implementation only dependencies for source set 'main'. (n)
\--- com.dumbdogdiner:stickyapi-common:3.0.2 (n)

runtimeClasspath - Runtime classpath of source set 'main'.
\--- com.dumbdogdiner:stickyapi-common:3.0.2
     +--- org.jetbrains:annotations:20.1.0
     +--- io.github.classgraph:classgraph:4.8.104
     +--- com.github.seancfoley:ipaddress:5.3.3
     +--- com.google.code.gson:gson:2.8.6
     \--- com.dumbdogdiner:stickyapi-config:3.0.2
          +--- org.jetbrains:annotations:20.1.0
          +--- io.github.classgraph:classgraph:4.8.104
          \--- com.github.seancfoley:ipaddress:5.3.3

runtimeElements - Elements of runtime for main. (n)
No dependencies

runtimeOnly - Runtime only dependencies for source set 'main'. (n)
No dependencies

testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
No dependencies

testCompileClasspath - Compile classpath for source set 'test'.
\--- com.dumbdogdiner:stickyapi-common:3.0.2
     \--- com.dumbdogdiner:stickyapi-config:3.0.2

testCompileOnly - Compile only dependencies for source set 'test'. (n)
No dependencies

testImplementation - Implementation only dependencies for source set 'test'. (n)
No dependencies

testRuntimeClasspath - Runtime classpath of source set 'test'.
\--- com.dumbdogdiner:stickyapi-common:3.0.2
     +--- org.jetbrains:annotations:20.1.0
     +--- io.github.classgraph:classgraph:4.8.104
     +--- com.github.seancfoley:ipaddress:5.3.3
     +--- com.google.code.gson:gson:2.8.6
     \--- com.dumbdogdiner:stickyapi-config:3.0.2
          +--- org.jetbrains:annotations:20.1.0
          +--- io.github.classgraph:classgraph:4.8.104
          \--- com.github.seancfoley:ipaddress:5.3.3

testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
No dependencies

(*) - dependencies omitted (listed previously)

(n) - Not resolved (configuration is not meant to be resolved)

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 2s
1 actionable task: 1 executed
```

# Bungee
`implementation "com.dumbdogdiner:stickyapi-bungee:3.0.2"`
```groovy
> Task :dependencies

------------------------------------------------------------
Root project
------------------------------------------------------------

annotationProcessor - Annotation processors and their dependencies for source set 'main'.
No dependencies

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts. (n)
No dependencies

compileClasspath - Compile classpath for source set 'main'.
\--- com.dumbdogdiner:stickyapi-bungee:3.0.2

compileOnly - Compile only dependencies for source set 'main'. (n)
No dependencies

default - Configuration for default artifacts. (n)
No dependencies

implementation - Implementation only dependencies for source set 'main'. (n)
\--- com.dumbdogdiner:stickyapi-bungee:3.0.2 (n)

runtimeClasspath - Runtime classpath of source set 'main'.
\--- com.dumbdogdiner:stickyapi-bungee:3.0.2
     +--- org.jetbrains:annotations:20.1.0
     +--- io.github.classgraph:classgraph:4.8.104
     +--- com.github.seancfoley:ipaddress:5.3.3
     \--- com.dumbdogdiner:stickyapi-common:3.0.2
          +--- org.jetbrains:annotations:20.1.0
          +--- io.github.classgraph:classgraph:4.8.104
          +--- com.github.seancfoley:ipaddress:5.3.3
          +--- com.google.code.gson:gson:2.8.6
          \--- com.dumbdogdiner:stickyapi-config:3.0.2
               +--- org.jetbrains:annotations:20.1.0
               +--- io.github.classgraph:classgraph:4.8.104
               \--- com.github.seancfoley:ipaddress:5.3.3

runtimeElements - Elements of runtime for main. (n)
No dependencies

runtimeOnly - Runtime only dependencies for source set 'main'. (n)
No dependencies

testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
No dependencies

testCompileClasspath - Compile classpath for source set 'test'.
\--- com.dumbdogdiner:stickyapi-bungee:3.0.2

testCompileOnly - Compile only dependencies for source set 'test'. (n)
No dependencies

testImplementation - Implementation only dependencies for source set 'test'. (n)
No dependencies

testRuntimeClasspath - Runtime classpath of source set 'test'.
\--- com.dumbdogdiner:stickyapi-bungee:3.0.2
     +--- org.jetbrains:annotations:20.1.0
     +--- io.github.classgraph:classgraph:4.8.104
     +--- com.github.seancfoley:ipaddress:5.3.3
     \--- com.dumbdogdiner:stickyapi-common:3.0.2
          +--- org.jetbrains:annotations:20.1.0
          +--- io.github.classgraph:classgraph:4.8.104
          +--- com.github.seancfoley:ipaddress:5.3.3
          +--- com.google.code.gson:gson:2.8.6
          \--- com.dumbdogdiner:stickyapi-config:3.0.2
               +--- org.jetbrains:annotations:20.1.0
               +--- io.github.classgraph:classgraph:4.8.104
               \--- com.github.seancfoley:ipaddress:5.3.3

testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
No dependencies

(*) - dependencies omitted (listed previously)

(n) - Not resolved (configuration is not meant to be resolved)

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 2s
1 actionable task: 1 executed
```

# Bukkit
`implementation "com.dumbdogdiner:stickyapi-bukkit:3.0.2"`
```groovy
> Task :dependencies

------------------------------------------------------------
Root project
------------------------------------------------------------

annotationProcessor - Annotation processors and their dependencies for source set 'main'.
No dependencies

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts. (n)
No dependencies

compileClasspath - Compile classpath for source set 'main'.
\--- com.dumbdogdiner:stickyapi-bukkit:3.0.2

compileOnly - Compile only dependencies for source set 'main'. (n)
No dependencies

default - Configuration for default artifacts. (n)
No dependencies

implementation - Implementation only dependencies for source set 'main'. (n)
\--- com.dumbdogdiner:stickyapi-bukkit:3.0.2 (n)

runtimeClasspath - Runtime classpath of source set 'main'.
\--- com.dumbdogdiner:stickyapi-bukkit:3.0.2
     +--- org.jetbrains:annotations:20.1.0
     +--- io.github.classgraph:classgraph:4.8.104
     +--- com.github.seancfoley:ipaddress:5.3.3
     \--- com.dumbdogdiner:stickyapi-common:3.0.2
          +--- org.jetbrains:annotations:20.1.0
          +--- io.github.classgraph:classgraph:4.8.104
          +--- com.github.seancfoley:ipaddress:5.3.3
          +--- com.google.code.gson:gson:2.8.6
          \--- com.dumbdogdiner:stickyapi-config:3.0.2
               +--- org.jetbrains:annotations:20.1.0
               +--- io.github.classgraph:classgraph:4.8.104
               \--- com.github.seancfoley:ipaddress:5.3.3

runtimeElements - Elements of runtime for main. (n)
No dependencies

runtimeOnly - Runtime only dependencies for source set 'main'. (n)
No dependencies

testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
No dependencies

testCompileClasspath - Compile classpath for source set 'test'.
\--- com.dumbdogdiner:stickyapi-bukkit:3.0.2

testCompileOnly - Compile only dependencies for source set 'test'. (n)
No dependencies

testImplementation - Implementation only dependencies for source set 'test'. (n)
No dependencies

testRuntimeClasspath - Runtime classpath of source set 'test'.
\--- com.dumbdogdiner:stickyapi-bukkit:3.0.2
     +--- org.jetbrains:annotations:20.1.0
     +--- io.github.classgraph:classgraph:4.8.104
     +--- com.github.seancfoley:ipaddress:5.3.3
     \--- com.dumbdogdiner:stickyapi-common:3.0.2
          +--- org.jetbrains:annotations:20.1.0
          +--- io.github.classgraph:classgraph:4.8.104
          +--- com.github.seancfoley:ipaddress:5.3.3
          +--- com.google.code.gson:gson:2.8.6
          \--- com.dumbdogdiner:stickyapi-config:3.0.2
               +--- org.jetbrains:annotations:20.1.0
               +--- io.github.classgraph:classgraph:4.8.104
               \--- com.github.seancfoley:ipaddress:5.3.3

testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
No dependencies

(*) - dependencies omitted (listed previously)

(n) - Not resolved (configuration is not meant to be resolved)

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```

# Config
`implementation "com.dumbdogdiner:stickyapi-config:3.0.2"`
```groovy
> Task :dependencies

------------------------------------------------------------
Root project
------------------------------------------------------------

annotationProcessor - Annotation processors and their dependencies for source set 'main'.
No dependencies

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts. (n)
No dependencies

compileClasspath - Compile classpath for source set 'main'.
\--- com.dumbdogdiner:stickyapi-config:3.0.2

compileOnly - Compile only dependencies for source set 'main'. (n)
No dependencies

default - Configuration for default artifacts. (n)
No dependencies

implementation - Implementation only dependencies for source set 'main'. (n)
\--- com.dumbdogdiner:stickyapi-config:3.0.2 (n)

runtimeClasspath - Runtime classpath of source set 'main'.
\--- com.dumbdogdiner:stickyapi-config:3.0.2
     +--- org.jetbrains:annotations:20.1.0
     +--- io.github.classgraph:classgraph:4.8.104
     \--- com.github.seancfoley:ipaddress:5.3.3

runtimeElements - Elements of runtime for main. (n)
No dependencies

runtimeOnly - Runtime only dependencies for source set 'main'. (n)
No dependencies

testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
No dependencies

testCompileClasspath - Compile classpath for source set 'test'.
\--- com.dumbdogdiner:stickyapi-config:3.0.2

testCompileOnly - Compile only dependencies for source set 'test'. (n)
No dependencies

testImplementation - Implementation only dependencies for source set 'test'. (n)
No dependencies

testRuntimeClasspath - Runtime classpath of source set 'test'.
\--- com.dumbdogdiner:stickyapi-config:3.0.2
     +--- org.jetbrains:annotations:20.1.0
     +--- io.github.classgraph:classgraph:4.8.104
     \--- com.github.seancfoley:ipaddress:5.3.3

testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
No dependencies

(n) - Not resolved (configuration is not meant to be resolved)

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```